### PR TITLE
Use VPS public IP in proxy.yaml to avoid DNS pollution

### DIFF
--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -20,6 +20,7 @@ type Parameters struct {
 	PrivateKey string
 	PublicKey  string
 	ShortID    string
+	PublicIP   string
 	DestHost   string
 	Port       int
 }

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -15,6 +15,7 @@ func sampleParameters() Parameters {
 		PrivateKey: "private-key",
 		PublicKey:  "public-key",
 		ShortID:    "0123456789abcdef",
+		PublicIP:   "1.2.3.4",
 		DestHost:   DefaultDestHost,
 		Port:       DefaultPort,
 	}
@@ -57,5 +58,13 @@ func TestRenderFlClash(t *testing.T) {
 
 	if string(data) != string(want) {
 		t.Fatalf("rendered flclash config mismatch.\n--- got ---\n%s\n--- want ---\n%s", string(data), string(want))
+	}
+
+	text := string(data)
+	if !strings.Contains(text, "server: 1.2.3.4") {
+		t.Fatalf("rendered flclash config should use public IP as server:\n%s", text)
+	}
+	if strings.Contains(text, "server: xx.example.com") {
+		t.Fatalf("rendered flclash config should not use domain as server:\n%s", text)
 	}
 }

--- a/internal/config/templates/proxy.yaml.tmpl
+++ b/internal/config/templates/proxy.yaml.tmpl
@@ -196,7 +196,7 @@ proxies:
 
   - name: {{ q .NodeName }}
     type: vless
-    server: {{ .Domain }}          # ←←← 改成你解析的子域名（或直接填 VPS IP）
+    server: {{ .PublicIP }}          # ←←← 改成你解析的子域名（或直接填 VPS IP）
     port: {{ .Port }}
     uuid: {{ q .UUID }}                   # ←←← 改成服务端生成的 UUID
     network: tcp

--- a/internal/config/testdata/proxy.yaml.golden
+++ b/internal/config/testdata/proxy.yaml.golden
@@ -196,7 +196,7 @@ proxies:
 
   - name: "测试节点 \"A\""
     type: vless
-    server: xx.example.com          # ←←← 改成你解析的子域名（或直接填 VPS IP）
+    server: 1.2.3.4          # ←←← 改成你解析的子域名（或直接填 VPS IP）
     port: 443
     uuid: "12345678-1234-1234-1234-1234567890ab"                   # ←←← 改成服务端生成的 UUID
     network: tcp

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -78,7 +78,12 @@ func (i *Installer) Run(ctx context.Context, req InstallRequest) (*Result, error
 	nodeName := DefaultNodeName
 
 	i.step("运行安装前检查")
-	publicIP, err := i.preflight(ctx, !req.DryRun)
+	var publicIP string
+	if req.DryRun {
+		publicIP, err = detectPublicIPv4(ctx)
+	} else {
+		publicIP, err = i.preflight(ctx, true)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -115,6 +120,7 @@ func (i *Installer) Run(ctx context.Context, req InstallRequest) (*Result, error
 		PrivateKey: privateKey,
 		PublicKey:  publicKey,
 		ShortID:    shortID,
+		PublicIP:   publicIP,
 		DestHost:   config.DefaultDestHost,
 		Port:       config.DefaultPort,
 	}
@@ -149,7 +155,7 @@ func (i *Installer) Run(ctx context.Context, req InstallRequest) (*Result, error
 		if err := i.validateDryRun(ctx, xrayConfig); err != nil {
 			return nil, err
 		}
-		i.printDryRunSummary(result)
+		i.printDryRunSummary(result, flClashConfig)
 		return result, nil
 	}
 
@@ -401,7 +407,7 @@ func (i *Installer) printSummary(result *Result) {
 	fmt.Fprintf(i.stdout, "\n获取 FlClash 配置命令：\n  sudo cat %s\n", result.ProxyConfigPath)
 }
 
-func (i *Installer) printDryRunSummary(result *Result) {
+func (i *Installer) printDryRunSummary(result *Result, flClashConfig []byte) {
 	fmt.Fprintln(i.stdout, "\nDry run 完成，未对系统做任何修改。")
 	fmt.Fprintf(i.stdout, "- domain: %s\n", result.Domain)
 	fmt.Fprintf(i.stdout, "- node name: %s\n", result.NodeName)
@@ -409,7 +415,12 @@ func (i *Installer) printDryRunSummary(result *Result) {
 	fmt.Fprintf(i.stdout, "- would write xray config to: %s\n", result.XrayConfigPath)
 	fmt.Fprintf(i.stdout, "- would write flclash config to: %s\n", result.ProxyConfigPath)
 	fmt.Fprintf(i.stdout, "- would save install record to: %s\n", metadataPath)
-	fmt.Fprintf(i.stdout, "\n实际安装完成后可用以下命令获取 FlClash 配置：\n  sudo cat %s\n", result.ProxyConfigPath)
+	fmt.Fprintf(i.stdout, "\n--- proxy.yaml preview ---\n%s", flClashConfig)
+	if len(flClashConfig) == 0 || flClashConfig[len(flClashConfig)-1] != '\n' {
+		fmt.Fprintln(i.stdout)
+	}
+	fmt.Fprintln(i.stdout, "--- end proxy.yaml preview ---")
+	fmt.Fprintf(i.stdout, "\nFlClash 配置预览已在上方输出。实际安装完成后可用以下命令获取配置文件：\n  sudo cat %s\n", result.ProxyConfigPath)
 }
 
 func normalizeDomain(input string) (string, error) {

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -57,7 +57,7 @@ func TestPrintSummaryIncludesFlClashCommand(t *testing.T) {
 	}
 }
 
-func TestPrintDryRunSummaryIncludesFlClashCommandHint(t *testing.T) {
+func TestPrintDryRunSummaryIncludesFlClashPreview(t *testing.T) {
 	t.Parallel()
 
 	var stdout bytes.Buffer
@@ -68,10 +68,16 @@ func TestPrintDryRunSummaryIncludesFlClashCommandHint(t *testing.T) {
 		PublicIP:        "1.2.3.4",
 		XrayConfigPath:  xrayConfigPath,
 		ProxyConfigPath: proxyConfigPath,
-	})
+	}, []byte("proxies:\n  - type: vless\n    server: 1.2.3.4\n"))
 
-	if !strings.Contains(stdout.String(), "sudo cat "+proxyConfigPath) {
-		t.Fatalf("dry-run summary missing flclash fetch command hint: %q", stdout.String())
+	if !strings.Contains(stdout.String(), "--- proxy.yaml preview ---") {
+		t.Fatalf("dry-run summary missing flclash preview start marker: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "server: 1.2.3.4") {
+		t.Fatalf("dry-run summary missing flclash preview: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "--- end proxy.yaml preview ---") {
+		t.Fatalf("dry-run summary missing flclash preview end marker: %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
Use the detected VPS public IP for the VLESS `server` field in
generated `proxy.yaml` instead of the domain.

This helps avoid DNS pollution and incorrect client-side DNS
  resolution.

 `--dry-run` now also prints a `proxy.yaml` preview so the
  generated config can be checked before installation.