### PR TITLE
将 FlClash TUN MTU 设为 1500

### DIFF
--- a/internal/config/templates/proxy.yaml.tmpl
+++ b/internal/config/templates/proxy.yaml.tmpl
@@ -114,7 +114,7 @@ sniffer:
 tun:
   enable: true
   stack: gvisor
-  mtu: 9000
+  mtu: 1500
   dns-hijack:
     - "any:53"
     - "tcp://any:53"

--- a/internal/config/testdata/proxy.yaml.golden
+++ b/internal/config/testdata/proxy.yaml.golden
@@ -114,7 +114,7 @@ sniffer:
 tun:
   enable: true
   stack: gvisor
-  mtu: 9000
+  mtu: 1500
   dns-hijack:
     - "any:53"
     - "tcp://any:53"


### PR DESCRIPTION
## 摘要

- 将生成的 FlClash 配置里的 TUN MTU 从 `9000` 改为 `1500`
- 同步更新渲染配置的 golden 文件，保持现有快照测试通过

## 原因

`9000` 是巨型帧 MTU，不适合作为移动网络默认值。

在使用移动数据时，过大的 MTU 会增加 IP 分片和丢包风险。DNS over HTTPS 请求受影响时，fake-IP 映射可能无法及时建立，进而导致域名规则无法命中，流量落到国内直连规则。在使用 WiFi 时就没那么明显。

`1500` 是更保守的默认值。本次就改了一个 MTU 参数。

## 验证

- `go test ./...`
- `go build ./cmd/xray-installer`
