### PR TITLE
修复对 Flclash v0.8.93 之后版本的兼容问题

### DIFF
--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -58,4 +58,12 @@ func TestRenderFlClash(t *testing.T) {
 	if string(data) != string(want) {
 		t.Fatalf("rendered flclash config mismatch.\n--- got ---\n%s\n--- want ---\n%s", string(data), string(want))
 	}
+
+	text := string(data)
+	if strings.Contains(text, "global-client-fingerprint:") {
+		t.Fatal("rendered flclash config contains removed global-client-fingerprint")
+	}
+	if !strings.Contains(text, "    client-fingerprint: random\n    reality-opts:") {
+		t.Fatal("rendered VLESS Reality proxy is missing node-level client-fingerprint")
+	}
 }

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -58,12 +58,4 @@ func TestRenderFlClash(t *testing.T) {
 	if string(data) != string(want) {
 		t.Fatalf("rendered flclash config mismatch.\n--- got ---\n%s\n--- want ---\n%s", string(data), string(want))
 	}
-
-	text := string(data)
-	if strings.Contains(text, "global-client-fingerprint:") {
-		t.Fatal("rendered flclash config contains removed global-client-fingerprint")
-	}
-	if !strings.Contains(text, "    client-fingerprint: random\n    reality-opts:") {
-		t.Fatal("rendered VLESS Reality proxy is missing node-level client-fingerprint")
-	}
 }

--- a/internal/config/templates/proxy.yaml.tmpl
+++ b/internal/config/templates/proxy.yaml.tmpl
@@ -46,7 +46,6 @@ external-ui-url: "https://hub.mirrors.2020818.xyz/https://github.com/MetaCubeX/m
 
 # 匹配进程 always/strict/off
 find-process-mode: strict
-global-client-fingerprint: random
 keep-alive-idle: 600
 keep-alive-interval: 30
 
@@ -204,6 +203,7 @@ proxies:
     tls: true
     flow: xtls-rprx-vision
     servername: {{ .DestHost }}     # ←←← 和服务端 dest 保持一致
+    client-fingerprint: random
     reality-opts:
       public-key: {{ q .PublicKey }}     # ←←← 改成服务端 xray x25519 生成的 PublicKey
       short-id: {{ q .ShortID }}   # ←←← 和服务端 shortIds 保持一致

--- a/internal/config/testdata/proxy.yaml.golden
+++ b/internal/config/testdata/proxy.yaml.golden
@@ -46,7 +46,6 @@ external-ui-url: "https://hub.mirrors.2020818.xyz/https://github.com/MetaCubeX/m
 
 # 匹配进程 always/strict/off
 find-process-mode: strict
-global-client-fingerprint: random
 keep-alive-idle: 600
 keep-alive-interval: 30
 
@@ -204,6 +203,7 @@ proxies:
     tls: true
     flow: xtls-rprx-vision
     servername: www.apple.com     # ←←← 和服务端 dest 保持一致
+    client-fingerprint: random
     reality-opts:
       public-key: "public-key"     # ←←← 改成服务端 xray x25519 生成的 PublicKey
       short-id: "0123456789abcdef"   # ←←← 和服务端 shortIds 保持一致


### PR DESCRIPTION
- ### **怎么回事**
Flclash 在 v0.8.94  (https://github.com/chen08209/Clash.Meta/commit/bd72c65b5e93c0790abb09b95d519aaf644c4b81) 已删除 global-client-fingerprint 的回退，并要求在代理节点上直接设置 client-fingerprint 

- ### **后果是什么**
模板顶层的 global-client-fingerprint 不会被读取，节点内部也缺少 client-fingerprint ，这导致升级 Flclash到 v0.8.93 以上的版本就无法使用

- ### **我改了什么**
所以我删掉了模板顶层的  global-client-fingerprint ，在节点内部加了client-fingerprint ，并保持 client-fingerprint: random 

- ### **测试结果**
 我手动改了 Flclash 里的配置文件，在 v0.8.96 里面可以正常运行


